### PR TITLE
Update get_links.py

### DIFF
--- a/get_links.py
+++ b/get_links.py
@@ -50,6 +50,8 @@ def go_to_listings(driver):
         # fill in with pre-defined data
         position_field.send_keys(PREFERENCES['position_title'])
         location_field.clear()
+        location_field.send_keys(Keys.CONTROL + "a")
+        location_field.send_keys(Keys.DELETE)
         location_field.send_keys(PREFERENCES['location'])
 
         # wait for a little so location gets set


### PR DESCRIPTION
Add additional clearing by sending Ctrl+A and DELETE keys to sc.location field in case it's not empty (this maybe an issue only on Windows, haven't checked on other OS).
In my case, the field was pre-filled with location retrieved through my internet provider and the script just added my configured location which led to erroneous job postings.